### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,31 +24,31 @@ GEM
     ffi (1.17.3-x86_64-linux-gnu)
     ffi (1.17.3-x86_64-linux-musl)
     forwardable-extended (2.6.0)
-    google-protobuf (4.33.4)
+    google-protobuf (4.33.5)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.33.4-aarch64-linux-gnu)
+    google-protobuf (4.33.5-aarch64-linux-gnu)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.33.4-aarch64-linux-musl)
+    google-protobuf (4.33.5-aarch64-linux-musl)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.33.4-arm64-darwin)
+    google-protobuf (4.33.5-arm64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.33.4-x86-linux-gnu)
+    google-protobuf (4.33.5-x86-linux-gnu)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.33.4-x86-linux-musl)
+    google-protobuf (4.33.5-x86-linux-musl)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.33.4-x86_64-darwin)
+    google-protobuf (4.33.5-x86_64-darwin)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.33.4-x86_64-linux-gnu)
+    google-protobuf (4.33.5-x86_64-linux-gnu)
       bigdecimal
       rake (>= 13)
-    google-protobuf (4.33.4-x86_64-linux-musl)
+    google-protobuf (4.33.5-x86_64-linux-musl)
       bigdecimal
       rake (>= 13)
     http_parser.rb (0.8.1)


### PR DESCRIPTION
## Summary
- Checked all direct dependencies for updates
- Updated google-protobuf from 4.33.4 to 4.33.5 (transitive dependency via Jekyll)
- Verified build passes after update

## Test plan
- [x] Ran individual dependency updates for each gem
- [x] Verified Jekyll build succeeds after each update
- [x] All dependencies are now at their latest compatible versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)