### PR TITLE
Remove duplicate config keys in _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,14 +22,6 @@ social:
 #chirpy
 avatar: /assets/10609708_672957986115083_7627741849738825230_n.png
 baseurl: ""
-compress_html:
-  clippings: all
-  comments: all
-  endings: all
-  profile: false
-  blanklines: false
-  ignore:
-    envs: [development]
 disqus:
   comments: true
   shortname: "interlake-high-school-memorial-wall"
@@ -51,10 +43,6 @@ kramdown:
       line_numbers: true
       start_line: 1
 lang: en-US
-permalink: /posts/:title/
-sass:
-  sass_dir: /assets/css
-  style: compressed
 theme_mode: dark
 timezone: America/Los_Angeles
 toc: true


### PR DESCRIPTION
## Summary
- `permalink`, `compress_html`, and `sass.style` were each defined twice in `_config.yml`
- YAML uses last-wins semantics, so the earlier definitions were silently ignored
- Removed the earlier (ignored) definitions to avoid confusion; no behavior change

## Test plan
- [ ] Verify the site builds without errors (`bundle exec jekyll build`)
- [ ] Confirm permalink format remains `/:categories/:title/`
- [ ] Confirm HTML compression and sass compression still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)