### PR TITLE
Add error handling to service worker fetch handler

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -32,15 +32,19 @@ self.addEventListener('install', (e) => {
 self.addEventListener('fetch', (e) => {
   e.respondWith(
     caches.match(e.request).then((r) => {
-      /* console.log('[Service Worker] Fetching resource: ' + e.request.url); */
       return r || fetch(e.request).then((response) => {
         return caches.open(cacheName).then((cache) => {
           if (!isExcluded(e.request.url)) {
-            /* console.log('[Service Worker] Caching new resource: ' + e.request.url); */
             cache.put(e.request, response.clone());
           }
           return response;
         });
+      });
+    }).catch(() => {
+      return new Response('You are offline and this page is not cached.', {
+        status: 503,
+        statusText: 'Service Unavailable',
+        headers: new Headers({ 'Content-Type': 'text/plain' })
       });
     })
   );


### PR DESCRIPTION
## Summary
- Add a `.catch()` to the service worker's fetch event handler so that when both the cache lookup and network fetch fail (e.g. the user is offline and the page isn't cached), a basic 503 "Service Unavailable" plain-text response is returned instead of an unhandled promise rejection.
- Remove commented-out console.log statements that were no longer needed.

## Test plan
- [ ] Verify the site loads normally with the service worker active
- [ ] Simulate offline mode in DevTools with a cleared cache and confirm the 503 fallback response is returned instead of a browser error
- [ ] Confirm previously cached pages still load correctly while offline

🤖 Generated with [Claude Code](https://claude.com/claude-code)