### PR TITLE
Update CDN dependencies to latest patch versions

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -24,25 +24,25 @@
   <link rel="dns-prefetch" href="https://cdn.jsdelivr.net" />
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css"
-    integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l"
+    href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css"
+    integrity="sha384-xOolHFLEh07PJGoPkLv1IbcEPTNtaed2xpHsD9ESMhqIYd0nLMwNLD69Npy4HI+N"
     crossorigin="anonymous"
   />
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.11.2/css/all.min.css"
-    integrity="sha256-+N4/V/SbAFiW1MPBCXnfnP9QSN3+Keu+NlB+0ev/YKQ="
+    href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/all.min.css"
+    integrity="sha384-DyZ88mC6Up2uqS4h/KRgHuoeGwBcD4Ng9SiP4dIRy0EXTlnuz47vAwmeGwVChigm"
     crossorigin="anonymous"
   />
   {% include css-selector.html %}
   <script
-    src="https://code.jquery.com/jquery-3.5.1.slim.min.js"
-    integrity="sha384-DfXdz2htPH0lsSSs5nCTpuj/zy4C+OGpamoFVy38MVBnE+IbbVYUew+OrCXaRkfj"
+    src="https://code.jquery.com/jquery-3.7.1.slim.min.js"
+    integrity="sha384-5AkRS45j4ukf+JbWAfHL8P4onPA9p0KwwP7pUdjSQA3ss9edbJUJc/XcYAiheSSz"
     crossorigin="anonymous"
   ></script>
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-Piv4xVNRyMGpqkS2by6br4gNJ7DXjqk09RmUpJ8jgGtD7zP9yug3goQfGII0yAns"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-Fy6S3B9q64WdZWQUiU+q4/2Lc9npb8tCaSX9FK7E8HnRr0Jz8D6OP9dO5Vg3Q9ct"
     crossorigin="anonymous"
   ></script>
   {% include js-selector.html %}


### PR DESCRIPTION
## Summary
- Bootstrap 4.6.0 -> 4.6.2 (CSS and JS bundle)
- Font Awesome 5.11.2 -> 5.15.4
- jQuery 3.5.1 slim -> 3.7.1 slim

All updates stay within the same major version for compatibility. SRI integrity hashes have been recomputed from the actual CDN files using `openssl dgst -sha384`.

## Test plan
- [ ] Verify the site loads without console errors (SRI hash mismatches would block resource loading)
- [ ] Confirm Bootstrap styling renders correctly
- [ ] Confirm Font Awesome icons display properly
- [ ] Confirm interactive Bootstrap components (dropdowns, modals) work via jQuery

🤖 Generated with [Claude Code](https://claude.com/claude-code)