### PR TITLE
Add lazy loading and improve image sizing in posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -30,7 +30,8 @@ comments: true
             src="{{ image }}"
             class="rounded"
             alt="{{ page.title | escape }}"
-            style="height: 350px"
+            loading="lazy"
+            style="max-height: 350px; width: auto"
           />
         </div>
         {% endfor %}


### PR DESCRIPTION
## Summary
- Add `loading="lazy"` to memorial post images to defer loading offscreen images
- Change `style="height: 350px"` to `style="max-height: 350px; width: auto"` for better responsiveness

## Test plan
- [ ] Verify memorial post images still display correctly
- [ ] Confirm images below the fold load lazily (check network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)