### PR TITLE
Remove --drafts flag from production build

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Build with Jekyll
-        run: JEKYLL_ENV=production bundle exec jekyll build --drafts --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: JEKYLL_ENV=production bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
 


### PR DESCRIPTION
## Summary
- Remove `--drafts` from the Jekyll build command in the GitHub Actions workflow
- Draft posts should not be published to the live production site

## Test plan
- [ ] Verify the site builds successfully without the --drafts flag
- [ ] Confirm draft posts are no longer published to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)