### PR TITLE
Remove redundant JEKYLL_ENV env block in workflow

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -34,8 +34,6 @@ jobs:
 
       - name: Build with Jekyll
         run: JEKYLL_ENV=production bundle exec jekyll build --drafts --baseurl "${{ steps.pages.outputs.base_path }}"
-        env:
-          JEKYLL_ENV: production
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v4


### PR DESCRIPTION
## Summary
- JEKYLL_ENV was set both inline (`JEKYLL_ENV=production bundle exec ...`) and via the `env:` block
- The inline version takes precedence, making the env block redundant
- Remove the `env:` block to avoid confusion

## Test plan
- [ ] Verify the workflow still sets JEKYLL_ENV correctly via the inline declaration

🤖 Generated with [Claude Code](https://claude.com/claude-code)