### PR TITLE
Add target=_blank and rel=noopener to obituary links

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,7 +21,7 @@ comments: true
         page.gender == 'female' %} {% assign pronoun = 'Her' %} {% endif %}
         <p>
           {{ pronoun }} obituary can be found
-          <a href="{{ page.obituary }}">here</a>.
+          <a href="{{ page.obituary }}" target="_blank" rel="noopener">here</a>.
         </p>
         {% endif %}
         {% for image in page.images %}


### PR DESCRIPTION
## Summary
- External obituary links now open in a new tab (`target="_blank"`)
- Include `rel="noopener"` for security
- Prevents navigating users away from the memorial page

## Test plan
- [ ] Verify obituary links on memorial posts open in a new tab
- [ ] Confirm `rel="noopener"` is present in the rendered HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)