### PR TITLE
URL-encode title and URL in share links

### DIFF
--- a/_includes/post-sharing.html
+++ b/_includes/post-sharing.html
@@ -9,7 +9,9 @@
     {% assign url = page.url | absolute_url %}
 
     {% for share in site.data.share.platforms %}
-      {% assign link = share.link | replace: 'TITLE', title | replace: 'URL', url %}
+      {% assign encoded_title = title | url_encode %}
+      {% assign encoded_url = url | url_encode %}
+      {% assign link = share.link | replace: 'TITLE', encoded_title | replace: 'URL', encoded_url %}
         <a href="{{ link }}" data-toggle="tooltip" data-placement="top"
           title="{{ share.type }}" target="_blank" rel="noopener" aria-label="{{ share.type }}">
           <i class="fa-fw {{ share.icon }}"></i>


### PR DESCRIPTION
## Summary
- Post titles containing special characters (`&`, `#`, quotes) broke share URLs
- Apply `url_encode` filter to both title and URL before substituting into share link templates

## Test plan
- [ ] Test sharing a post with special characters in the title (e.g. `Marjorie Nell "Marji" Hansen`)
- [ ] Verify Twitter/Facebook/Telegram share links work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)