### PR TITLE
Improve email address obfuscation in sidebar

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -54,7 +54,7 @@
           https://x.com/{{ site.twitter.username }}
         {%- elsif entry.type == 'email' -%}
           {% assign email = site.social.email | split: '@' %}
-          javascript:location.href = 'mailto:' + ['{{ email[0] }}','{{ email[1] }}'].join('@')
+          javascript:void(function(){var a='{{ email[0] }}',b='{{ email[1] }}';location.href='mai'+'lto:'+a+'%40'+b}())
         {%- elsif entry.type == 'rss' -%}
           {{ "/feed.xml" | relative_url }}
         {%- else -%}


### PR DESCRIPTION
## Summary
- Split the `mailto:` protocol string and use `%40` instead of `@` to make the email harder for simple scrapers to extract
- Wraps in `javascript:void(function(){...}())` for cleaner execution

## Test plan
- [ ] Verify clicking the email icon still opens the correct mailto link
- [ ] Confirm the email address is not visible as a plain `mailto:` in the page source

🤖 Generated with [Claude Code](https://claude.com/claude-code)