### PR TITLE
Remove unused jekyll-archives plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gem "jekyll"
 gem "logger"
 
 group :jekyll_plugins do
-  gem "jekyll-archives", "~> 2.2"
   gem "jekyll-paginate", "~> 1.1"
   gem "jekyll-redirect-from", "~> 0.16"
   gem "jekyll-seo-tag", "~> 2.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,8 +73,6 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-archives (2.3.0)
-      jekyll (>= 3.6, < 5.0)
     jekyll-paginate (1.1.0)
     jekyll-redirect-from (0.16.0)
       jekyll (>= 3.3, < 5.0)
@@ -169,7 +167,6 @@ DEPENDENCIES
   base64
   csv
   jekyll
-  jekyll-archives (~> 2.2)
   jekyll-paginate (~> 1.1)
   jekyll-redirect-from (~> 0.16)
   jekyll-seo-tag (~> 2.7)

--- a/_config.yml
+++ b/_config.yml
@@ -122,8 +122,6 @@ exclude:
   - .github
   - script
 include: []
-jekyll-archives:
-  enabled: []
 paginate: 25
 permalink: /:categories/:title/
 repository: Interlake-Saints/ihsmemorial.org


### PR DESCRIPTION
## Summary
- Remove `jekyll-archives` from Gemfile and `_config.yml`
- The plugin was configured with `enabled: []`, so it did nothing
- Reduces unnecessary dependency

## Test plan
- [ ] Verify the site builds successfully without jekyll-archives
- [ ] Confirm no archive pages were being generated (they weren't)

🤖 Generated with [Claude Code](https://claude.com/claude-code)