### PR TITLE
Lazy-load Disqus comments with IntersectionObserver

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -5,10 +5,24 @@
     this.page.identifier = "{{ page.url }}";
   };
   (function () {
-    var d = document,
-      s = d.createElement("script");
-    s.src = "https://{{ site.disqus.shortname }}.disqus.com/embed.js";
-    s.setAttribute("data-timestamp", +new Date());
-    (d.head || d.body).appendChild(s);
+    var loadDisqus = function () {
+      var d = document,
+        s = d.createElement("script");
+      s.src = "https://{{ site.disqus.shortname }}.disqus.com/embed.js";
+      s.setAttribute("data-timestamp", +new Date());
+      (d.head || d.body).appendChild(s);
+    };
+    var target = document.getElementById("disqus_thread");
+    if ("IntersectionObserver" in window) {
+      var observer = new IntersectionObserver(function (entries) {
+        if (entries[0].isIntersecting) {
+          loadDisqus();
+          observer.disconnect();
+        }
+      }, { rootMargin: "200px" });
+      observer.observe(target);
+    } else {
+      loadDisqus();
+    }
   })();
 </script>


### PR DESCRIPTION
## Summary
- Wrap Disqus embed script loading in an IntersectionObserver callback
- Script only loads when `#disqus_thread` div is within 200px of viewport
- Falls back to eager loading for browsers without IntersectionObserver support

## Test plan
- [ ] Verify Disqus comments still load when scrolling to the bottom of a post
- [ ] Confirm the script is not loaded on initial page load (check network tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)