### PR TITLE
Update GitHub username from MarioMangler to MarioJLanza

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@ social:
   email: MLanza1974@aol.com
   links:
     - https://x.com/MarioJLanza
-    - https://github.com/MarioMangler
+    - https://github.com/MarioJLanza
     - https://www.facebook.com/mariolanza
 
 #chirpy
@@ -26,7 +26,7 @@ disqus:
   comments: true
   shortname: "interlake-high-school-memorial-wall"
 github:
-  username: MarioMangler
+  username: MarioJLanza
 img_cdn: ""
 kramdown:
   syntax_highlighter: rouge


### PR DESCRIPTION
## Summary
- Update `github.username` and `social.links` GitHub URL in `_config.yml` to reflect the account rename from MarioMangler to MarioJLanza

## Test plan
- [ ] Verify sidebar GitHub link points to https://github.com/MarioJLanza

🤖 Generated with [Claude Code](https://claude.com/claude-code)