### PR TITLE
Fix accessibility: use aria-label instead of alt on sidebar link

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -2,7 +2,7 @@
 
   <div class="profile-wrapper text-center">
     <div id="avatar">
-      <a href="{{ '/' | relative_url }}" alt="avatar" class="mx-auto">
+      <a href="{{ '/' | relative_url }}" aria-label="avatar" class="mx-auto">
         {% capture avatar_url %}
           {%- if site.avatar contains '://' -%}
             {{ site.avatar }}

--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -2,7 +2,7 @@
 
   <div class="profile-wrapper text-center">
     <div id="avatar">
-      <a href="{{ '/' | relative_url }}" aria-label="avatar" class="mx-auto">
+      <a href="{{ '/' | relative_url }}" aria-label="Home" class="mx-auto">
         {% capture avatar_url %}
           {%- if site.avatar contains '://' -%}
             {{ site.avatar }}


### PR DESCRIPTION
## Summary
- Replace invalid `alt` attribute on the sidebar avatar `<a>` tag with `aria-label` in `_includes/sidebar.html`
- The `alt` attribute is only valid on `<img>` elements; `aria-label` is the correct way to provide an accessible name for a link

## Test plan
- Verify the sidebar renders correctly and the avatar link still works
- Run an accessibility audit (e.g., axe or Lighthouse) to confirm the invalid `alt` warning is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)