### PR TITLE
Remove dead PKCE auth config from Decap CMS

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -2,11 +2,6 @@ backend:
   name: github
   repo: Interlake-Saints/ihsmemorial.org
   branch: main
-  # PKCE auth allows client-side only OAuth (no backend proxy needed)
-  # Create a GitHub OAuth App at: https://github.com/settings/developers
-  # Set callback URL to: https://api.decapcms.org/callback
-  auth_type: pkce
-  app_id: Ov23liXrfdwyNE5yaVFe
 collections:
   - name: "deaths"
     label: "Deaths"


### PR DESCRIPTION
## Summary

Remove `auth_type: pkce`, `app_id`, and related comments from the Decap CMS backend configuration. The GitHub backend does not support PKCE authentication — these settings were silently ignored, and auth falls back to Netlify's OAuth proxy regardless. Removing them prevents confusion for future maintainers.

## Changes

- Removed `auth_type: pkce` setting
- Removed `app_id: Ov23liXrfdwyNE5yaVFe` setting
- Removed associated instructional comments about PKCE setup

## Testing

- Verify the Decap CMS admin panel still loads and authenticates correctly at `/admin/`
- Authentication should continue working through Netlify's OAuth proxy as before

---
Generated with [Claude Code](https://claude.com/claude-code)